### PR TITLE
Added SequenceRNAStringSetTrack class

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -31,7 +31,7 @@ importMethodsFrom(rtracklayer, chrom, close, getTable, "tableName<-", track,
                   import.bw, import.ucsc, import.bed, import.bedGraph, import.chain,
                   import.wig, seqinfo)
 
-importMethodsFrom(Biostrings, seqtype, seqtype<-, consensusMatrix, consensusString, unmasked, complement)
+importMethodsFrom(Biostrings, seqtype, "seqtype<-", consensusMatrix, consensusString, unmasked, complement)
 
 
 importFrom(Biobase, listLen, rowMax, rowMin)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -31,7 +31,7 @@ importMethodsFrom(rtracklayer, chrom, close, getTable, "tableName<-", track,
                   import.bw, import.ucsc, import.bed, import.bedGraph, import.chain,
                   import.wig, seqinfo)
 
-importMethodsFrom(Biostrings, consensusMatrix, consensusString, unmasked, complement)
+importMethodsFrom(Biostrings, seqtype, seqtype<-, consensusMatrix, consensusString, unmasked, complement)
 
 
 importFrom(Biobase, listLen, rowMax, rowMin)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,7 +10,7 @@ import(grid)
 
 importClassesFrom(biomaRt, Mart)
 
-importClassesFrom(Biostrings, DNAStringSet, BStringSet, DNAString, BString)
+importClassesFrom(Biostrings, DNAStringSet, RNAStringSet, BStringSet, DNAString, RNAString, BString)
 
 importClassesFrom(BSgenome, BSgenome, MaskedBSgenome)
 
@@ -36,7 +36,7 @@ importMethodsFrom(Biostrings, consensusMatrix, consensusString, unmasked, comple
 
 importFrom(Biobase, listLen, rowMax, rowMin)
 
-importFrom(Biostrings, DNAStringSet, BStringSet, DNAString, BString, reverseComplement, readDNAStringSet, DNA_ALPHABET, stackStrings)
+importFrom(Biostrings, DNAStringSet, RNAStringSet, BStringSet, DNAString, RNAString, BString, reverseComplement, readDNAStringSet, DNA_ALPHABET, stackStrings)
 
 importFrom(biomaRt, getBM, useMart, listDatasets, listAttributes, listFilters)
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -1963,7 +1963,6 @@ setClass("SequenceTrack",
                                             background.title="transparent",
                                             col="darkgray",
                                             complement=FALSE,
-                                            fontcolor=getBioColor("DNA_BASES_N"),
                                             fontface=2,
                                             fontsize=10,
                                             lwd=2,
@@ -1979,10 +1978,16 @@ setMethod("initialize", "SequenceTrack", function(.Object, chromosome, genome, .
     ## the diplay parameter defaults
     .makeParMapping()
     .Object <- .updatePars(.Object, "SequenceTrack")
-     if(!missing(chromosome) && !is.null(chromosome)){
+    if(!missing(chromosome) && 
+       !is.na(chromosome) && 
+       !is.null(chromosome)){
+      if(!is.null(names(sequence))){
+        .Object@chromosome <- .chrName(names(sequence)[1])[1]
+      } else {
         .Object@chromosome <- .chrName(chromosome)[1]
+      }
     }
-    if(missing(genome) || is.null(genome))
+    if(missing(genome) || is.na(genome) || is.null(genome))
         genome <- as.character(NA)
     .Object@genome <- genome
     .Object <- callNextMethod(.Object, ...)
@@ -1995,10 +2000,10 @@ setMethod("initialize", "SequenceTrack", function(.Object, chromosome, genome, .
 ##      chromosome if available, and genome as supplied or NA if missing
 ##   c) sequence is BSgenome => build SequenceBSgenomeTrack where chromosome is seqnames(sequence)[1] or the supplied
 ##      chromosome if available, and genome is the supplied genome or the one extracted from the BSgenome object
-SequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", importFunction, stream=FALSE, ...){
+.SequenceTrack <- function(SeqTrackType, seqtype, sequence, chromosome, genome, name="SequenceTrack", importFunction, stream=FALSE, ...){
     .missingToNull(c("chromosome", "genome", "sequence"))
     if(is.null(sequence)){
-        return(new("SequenceDNAStringSetTrack", chromosome=chromosome, genome=genome, name=name, ...))
+        return(new(SeqTrackType, chromosome=chromosome, genome=genome, name=name, ...))
     }
     if(is(sequence, "BSgenome")){
         if(is.null(genome))
@@ -2006,14 +2011,17 @@ SequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", im
         if(is.null(chromosome))
             chromosome <- seqnames(sequence)[1]
         obj <- new("SequenceBSgenomeTrack", sequence=sequence, chromosome=chromosome, genome=genome, name=name, ...)
-    }else if(is(sequence, "DNAStringSet")){
+    } else if(is(sequence, "XStringSet")){
+        if(seqtype(sequence) != seqtype){
+          seqtype(sequence) <- seqtype
+        }
         if(is.null(names(sequence)))
-            stop("The sequences in the DNAStringSet must be named")
+            stop("The sequences in the ",seqtype,"StringSet must be named")
         if(any(duplicated(names(sequence))))
-            stop("The sequence names in the DNAStringSet must be unique")
+            stop("The sequence names in the ",seqtype,"StringSet must be unique")
         if(is.null(chromosome))
             chromosome <- names(sequence)[1]
-        obj <- new("SequenceDNAStringSetTrack", sequence=sequence, chromosome=chromosome, genome=genome, name=name, ...)
+        obj <- new(SeqTrackType, sequence=sequence, chromosome=chromosome, genome=genome, name=name, ...)
     } else if(is.character(sequence)){
         sequence <- sequence[1]
         if(!file.exists(sequence))
@@ -2049,10 +2057,30 @@ SequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", im
             }
         }
     }else{
-        stop("Argument sequence must be of class 'BSgenome', 'DNAStringSet' or 'character'")
+        stop("Argument sequence must be of class 'BSgenome', 'XStringSet' or 'character'")
     }
     return(obj)
 }
+
+SequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", importFunction, stream=FALSE, ...){
+  .SequenceTrack("SequenceDNAStringSetTrack",
+                 "DNA",
+                 sequence,
+                 chromosome,
+                 genome,
+                 ...)
+}
+
+RNASequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", importFunction, stream=FALSE, ...){
+  .SequenceTrack("SequenceRNAStringSetTrack",
+                 "RNA",
+                 sequence,
+                 chromosome,
+                 genome,
+                 ...)
+}
+
+
 ##----------------------------------------------------------------------------------------------------------------------
 
 
@@ -2060,14 +2088,26 @@ SequenceTrack <- function(sequence, chromosome, genome, name="SequenceTrack", im
 ##----------------------------------------------------------------------------------------------------------------------
 ## SequenceDNAStringSetTrack:
 ##
-## A track to visualize nucleotide sequences that are stored in a DNSStringSet
+## A track to visualize nucleotide sequences that are stored in a DNAStringSet
 ## Slots:
 ##    o sequence: a DNAStringSet object that contains all the sequence data
 ##----------------------------------------------------------------------------------------------------------------------
 setClass("SequenceDNAStringSetTrack",
          representation=representation(sequence="DNAStringSet"),
          contains="SequenceTrack",
-         prototype=prototype(sequence=DNAStringSet()))
+         prototype=prototype(sequence=DNAStringSet(),
+                             dp=DisplayPars(add53=FALSE,
+                                            background.title="transparent",
+                                            col="darkgray",
+                                            complement=FALSE,
+                                            fontcolor=getBioColor("DNA_BASES_N"),
+                                            fontface=2,
+                                            fontsize=10,
+                                            lwd=2,
+                                            min.width=2,
+                                            noLetters=FALSE,
+                                            showTitle=FALSE,
+                                            size=NULL)))
 
 setMethod("initialize", "SequenceDNAStringSetTrack", function(.Object, sequence, ...) {
     if(missing(sequence) || is.null(sequence))
@@ -2075,6 +2115,38 @@ setMethod("initialize", "SequenceDNAStringSetTrack", function(.Object, sequence,
     .Object@sequence <- sequence
     .Object <- callNextMethod(.Object, ...)
      return(.Object)
+})
+##----------------------------------------------------------------------------------------------------------------------
+
+## SequenceRNAStringSetTrack:
+##
+## A track to visualize nucleotide sequences that are stored in a RNAStringSet
+## Slots:
+##    o sequence: a RNAStringSet object that contains all the sequence data
+##----------------------------------------------------------------------------------------------------------------------
+setClass("SequenceRNAStringSetTrack",
+         representation=representation(sequence="RNAStringSet"),
+         contains="SequenceTrack",
+         prototype=prototype(sequence=RNAStringSet(),
+                             dp=DisplayPars(add53=FALSE,
+                                            background.title="transparent",
+                                            col="darkgray",
+                                            complement=FALSE,
+                                            fontcolor=getBioColor("RNA_BASES_N"),
+                                            fontface=2,
+                                            fontsize=10,
+                                            lwd=2,
+                                            min.width=2,
+                                            noLetters=FALSE,
+                                            showTitle=FALSE,
+                                            size=NULL)))
+
+setMethod("initialize", "SequenceRNAStringSetTrack", function(.Object, sequence, ...) {
+  if(missing(sequence) || is.null(sequence))
+    sequence <- RNAStringSet()
+  .Object@sequence <- sequence
+  .Object <- callNextMethod(.Object, ...)
+  return(.Object)
 })
 ##----------------------------------------------------------------------------------------------------------------------
 

--- a/R/Gviz-methods.R
+++ b/R/Gviz-methods.R
@@ -133,7 +133,11 @@ setMethod("subseq", "SequenceTrack", function(x, start=NA, end=NA, width=NA){
         stop("'end' has to be bigger than 'start'")
     if((rend-rstart+1)>10e6)
         stop("Sequence is too big! Unable to extract")
-    class <- paste0(seqtype(x@sequence),"String")
+    seqtype <- try(seqtype(x@sequence))
+    if(is(seqtype,"try-error")){
+      seqtype <- "DNA"
+    }
+    class <- paste0(seqtype,"String")
     finalSeq <- rep(do.call(class,list(padding)), end-start+1)
     if(chromosome(x) %in% seqnames(x) && rend>=rstart){
         chrSeq <- x@sequence[[chromosome(x)]]

--- a/R/Gviz-methods.R
+++ b/R/Gviz-methods.R
@@ -19,6 +19,7 @@ setMethod("range", "GenomeAxisTrack", function(x) ranges(x@range))
 ## seqnames, levels and infofrom the range track
 setMethod("seqnames", "RangeTrack", function(x) as.character(seqnames(ranges(x))))
 setMethod("seqnames", "SequenceDNAStringSetTrack", function(x) as.character(names(x@sequence)))
+setMethod("seqnames", "SequenceRNAStringSetTrack", function(x) as.character(names(x@sequence)))
 setMethod("seqnames", "SequenceBSgenomeTrack", function(x) as.character(seqnames(x@sequence)))
 setMethod("seqlevels", "RangeTrack", function(x) unique(seqnames(x)))
 setMethod("seqlevels", "SequenceDNAStringSetTrack", function(x) seqnames(x)[width(x@sequence)>0])
@@ -132,7 +133,8 @@ setMethod("subseq", "SequenceTrack", function(x, start=NA, end=NA, width=NA){
         stop("'end' has to be bigger than 'start'")
     if((rend-rstart+1)>10e6)
         stop("Sequence is too big! Unable to extract")
-    finalSeq <- rep(DNAString(padding), end-start+1)
+    class <- paste0(seqtype(x@sequence),"String")
+    finalSeq <- rep(do.call(class,list(padding)), end-start+1)
     if(chromosome(x) %in% seqnames(x) && rend>=rstart){
         chrSeq <- x@sequence[[chromosome(x)]]
         seq <- subseq(chrSeq, start=rstart, end=rend)
@@ -4062,6 +4064,7 @@ setAs("GRangesList", "GeneRegionTrack", function(from, to) GeneRegionTrack(range
 setAs("TxDb", "GeneRegionTrack", function(from, to) GeneRegionTrack(range=from))
 
 setAs("DNAString", "Rle", function(from, to) Rle(strsplit(as.character(from), "")[[1]]))
+setAs("RNAString", "Rle", function(from, to) Rle(strsplit(as.character(from), "")[[1]]))
 
 setMethod("head", "InferredDisplayPars", function(x, n=10, ...){
     sel <- 1:min(n, length(x))
@@ -4583,6 +4586,7 @@ setMethod("show",signature(object="SequenceBSgenomeTrack"),
 
 ## Here we only need the name, genome and currently active chromosome information
 setMethod("show", signature(object="SequenceDNAStringSetTrack"), function(object) cat(.sequenceTrackInfo(object)))
+setMethod("show", signature(object="SequenceRNAStringSetTrack"), function(object) cat(.sequenceTrackInfo(object)))
 
 setMethod("show",signature(object="AlignedReadTrack"),
 		  function(object){

--- a/R/Gviz.R
+++ b/R/Gviz.R
@@ -1185,7 +1185,6 @@
                                                  cex=1,
                                                  col="darkgray",
                                                  complement=FALSE,
-                                                 fontcolor=getBioColor("DNA_BASES_N"),
                                                  fontface=2,
                                                  fontsize=10,
                                                  lwd=2,


### PR DESCRIPTION
Refactored some internals to support SequenceTrack object representing other nucleotide sequences than just DNA. For usage case see RNAmodR package, which uses additional XStringSet classes from the Modstrings package.