### PR TITLE
 Speed up of plotting AlignmentTrack when using big bam file 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Gviz
 Title: Plotting data and annotation information along genomic coordinates
-Version: 1.31.0
+Version: 1.31.1
 Authors@R: c(person("Florian", "Hahne", role="aut"),
              person("Steffen", "Durinck", role="aut"),
 	     person("Robert", "Ivanek", role=c("aut", "cre"), email="robert.ivanek@unibas.ch", comment=c(ORCID="0000-0002-8403-056X")),


### PR DESCRIPTION
Loading bamfiles with scanBam returns a list, which is quite ineffective to access when dealing with large bam files and a high number of reads to be displayed. Bioconductor offers a more effective accessor, `GAlignment` objects, which are implemented with the PR as drop in replacement of the existing functionality.