### PR TITLE
Fix current build failure in devel branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Gviz
 Title: Plotting data and annotation information along genomic coordinates
-Version: 1.35.3
+Version: 1.35.4
 Authors@R: c(person("Florian", "Hahne", role="aut"),
 	 person("Steffen", "Durinck", role="aut"),
 	 person("Robert", "Ivanek", role=c("aut", "cre"), email="robert.ivanek@unibas.ch", comment=c(ORCID="0000-0002-8403-056X")),

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -1863,7 +1863,7 @@ IdeogramTrack <- function(chromosome = NULL, genome, name = NULL, bands = NULL, 
                     tmp
                 }), env, cenv
             )
-            query <- tryCatch(ucscTableQuery(session, "cytoBandIdeo"), error = function(e) {
+            query <- tryCatch(ucscTableQuery(session, table = "cytoBandIdeo"), error = function(e) {
                 warning(
                     "There doesn't seem to be any cytoband data available for genome '", genome,
                     "' at UCSC or the service is temporarily down. Trying to fetch the chromosome length data."


### PR DESCRIPTION
Hi Robert,

This patch addresses the current build failure on the Bioc devel branch, which I think was introduced by changes to `ucscTableQuery()` in **rtracklayer**.  It looks like the order of the arguments might have changed, this just makes sure to specify that we're looking for the cytoband table inside the `IdeogramTrack()` function.

Let me know if anything else needs adding.